### PR TITLE
Make compatible with RN 0.47

### DIFF
--- a/lib/android/src/main/java/com/wix/interactable/Interactable.java
+++ b/lib/android/src/main/java/com/wix/interactable/Interactable.java
@@ -11,17 +11,17 @@ import java.util.List;
 
 public class Interactable implements ReactPackage {
 
-    @Override
+    // Deprecated RN 0.47
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.<ViewManager>singletonList(new InteractableViewManager());
     }


### PR DESCRIPTION
Fix a bug with RN 0.47

Reference
https://github.com/wix/react-native-interactable/issues/132

This hasn't been merged yet: 
https://github.com/fvicente/react-native-interactable/commit/0c1469bf2fc9d05cf98c67cffd7ee220d9f1790e

